### PR TITLE
Scoop update for transit version v1.2.2

### DIFF
--- a/bucket/transit.json
+++ b/bucket/transit.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.2.2",
+    "architecture": {
+        "arm64": {
+            "url": "https://github.com/ismailshak/transit/releases/download/v1.2.2/transit_Windows_arm64.zip",
+            "bin": [
+                "transit.exe"
+            ],
+            "hash": "b8ee76f4714592af1493b5ae1c910f78723e6a89a59bdeb1856ec3519abca805"
+        }
+    },
+    "homepage": "https://transitcli.com/",
+    "license": "MIT",
+    "description": "Cross platform tool that brings local transit information to the command line",
+    "shortcuts": [
+        [
+            "transit.exe",
+            "transit"
+        ]
+    ]
+}

--- a/bucket/transit.json
+++ b/bucket/transit.json
@@ -6,7 +6,7 @@
             "bin": [
                 "transit.exe"
             ],
-            "hash": "b8ee76f4714592af1493b5ae1c910f78723e6a89a59bdeb1856ec3519abca805"
+            "hash": "1127ecb5d451180bb22a20ff21124c4fac0d80c98708c62bac1218a0054568b1"
         }
     },
     "homepage": "https://transitcli.com/",


### PR DESCRIPTION

###### Automated with [GoReleaser](https://goreleaser.com)